### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", ruby-head, jruby-9.2, jruby-9.3]
+        rubocop_version: ["0.86", "1.20"]
+        exclude:
+          - ruby: "2.4"
+            rubocop_version: "1.20"
+    env:
+      BUNDLE_GEMFILE: "gemfiles/rubocop_${{ matrix.rubocop_version }}.gemfile"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true # 'bundle install' and cache gems
+        ruby-version: ${{ matrix.ruby }}
+    - name: Run tests
+      run: bundle exec rspec

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint 
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+    name: Rubocop
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true # 'bundle install' and cache gems
+        ruby-version: "2.7" 
+    - name: Run Rubocop 
+      run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 Lint/RaiseException:
   Enabled: true

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_runtime_dependency 'rubocop', '>= 0.53.0'
 


### PR DESCRIPTION
In addition to introducing a GitHub Actions configuration this PR:

1. Updates the minimum Ruby allowed for the gem to 2.5
2. Makes a similar change for the RequiredRubyVersion in the Rubocop config.

This minimum version change has been discussed with the maintainer.

Runs green on my fork.