### PR TITLE
Improve specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,10 @@ Style/AutoResourceCleanup:
 Style/CollectionMethods:
   Enabled: true
 
+Style/FormatStringToken:
+  Exclude:
+    - spec/**/*
+
 Style/FrozenStringLiteralComment:
   Exclude:
     - "gemfiles/*.gemfile"

--- a/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
+++ b/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
   shared_examples 'mutable objects' do |o|
     context 'when assigning with =' do
       it "registers an offense for #{o} assigned to a class ivar" do
-        expect_offense(surround(<<~RUBY))
-          @var = #{o}
-                 #{'^' * o.length} #{msg}
+        expect_offense(surround(<<~RUBY), o: o)
+          @var = %{o}
+                 ^{o} #{msg}
         RUBY
 
         expect_correction(surround(<<~RUBY))
@@ -31,9 +31,9 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
 
     context 'when assigning with ||=' do
       it "registers an offense for #{o} assigned to a class ivar" do
-        expect_offense(surround(<<~RUBY))
-          @var ||= #{o}
-                   #{'^' * o.length} #{msg}
+        expect_offense(surround(<<~RUBY), o: o)
+          @var ||= %{o}
+                   ^{o} #{msg}
         RUBY
 
         expect_correction(surround(<<~RUBY))
@@ -480,10 +480,9 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
         context 'when assigning with an operator' do
           shared_examples 'operator methods' do |o|
             it 'registers an offense' do
-              c = '^' * o.length
-              expect_offense(surround(<<~RUBY))
-                @var = FOO #{o} BAR
-                       ^^^^#{c}^^^^ #{msg}
+              expect_offense(surround(<<~RUBY), o: o)
+                @var = FOO %{o} BAR
+                       ^^^^^{o}^^^^ #{msg}
               RUBY
 
               expect_correction(surround(<<~RUBY))


### PR DESCRIPTION
By using `%{foo}`/`^{foo}` to [match variables of different lengths](https://github.com/rubocop/rubocop/blob/8ee7a428f51ea80b406d6d3b63a5fd7f9c32162c/lib/rubocop/rspec/expect_offense.rb#L75-L92), and `expect_correction` for validating the result of autocorrecting source code, I believe the specs are more readable and has less duplication.

Blocked by #3.