### PR TITLE
Improve performance with RESTRICT_ON_SEND

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", ruby-head, jruby-9.2, jruby-9.3]
-        rubocop_version: ["0.86", "1.20"]
+        rubocop_version: ["0.90", "1.20"]
     env:
       BUNDLE_GEMFILE: "gemfiles/rubocop_${{ matrix.rubocop_version }}.gemfile"
     steps:

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-appraise 'rubocop-0.86' do
-  gem 'rubocop', '~> 0.86.0'
+appraise 'rubocop-0.90' do
+  gem 'rubocop', '~> 0.90.0'
 end
 
 appraise 'rubocop-1.20' do

--- a/gemfiles/rubocop_0.90.gemfile
+++ b/gemfiles/rubocop_0.90.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rubocop", "~> 0.86.0"
+gem "rubocop", "~> 0.90.0"
 
 gemspec path: "../"

--- a/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
+++ b/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
@@ -14,6 +14,12 @@ module RuboCop
       #   end
       class ClassAndModuleAttributes < Cop
         MSG = 'Avoid mutating class and module attributes.'
+        RESTRICT_ON_SEND = %i[
+          mattr_writer mattr_accessor cattr_writer cattr_accessor
+          class_attribute
+          attr attr_accessor attr_writer
+          attr_internal attr_internal_accessor attr_internal_writer
+        ].freeze
 
         def_node_matcher :mattr?, <<~MATCHER
           (send nil?

--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -55,6 +55,10 @@ module RuboCop
       #   end
       class InstanceVariableInClassMethod < Cop
         MSG = 'Avoid instance variables in class methods.'
+        RESTRICT_ON_SEND = %i[
+          instance_variable_set
+          instance_variable_get
+        ].freeze
 
         def_node_matcher :instance_variable_set_call?, <<~MATCHER
           (send nil? :instance_variable_set (...) (...))

--- a/lib/rubocop/cop/thread_safety/new_thread.rb
+++ b/lib/rubocop/cop/thread_safety/new_thread.rb
@@ -12,6 +12,7 @@ module RuboCop
       #   Thread.new { do_work }
       class NewThread < Cop
         MSG = 'Avoid starting new threads.'
+        RESTRICT_ON_SEND = %i[new].freeze
 
         def_node_matcher :new_thread?, <<~MATCHER
           (send (const {nil? cbase} :Thread) :new)

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.53.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.90.0'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'

--- a/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
+++ b/spec/rubocop/cop/thread_safety/mutable_class_instance_variable_spec.rb
@@ -4,11 +4,6 @@ RSpec.describe RuboCop::Cop::ThreadSafety::MutableClassInstanceVariable,
                :config do
   subject(:cop) { described_class.new(config) }
   let(:msg) { 'Freeze mutable objects assigned to class instance variables.' }
-  if Gem::Requirement.new('< 0.69')
-                     .satisfied_by?(Gem::Version.new(RuboCop::Version::STRING))
-    let(:ruby_version) { 2.3 }
-  end
-
   let(:prefix) { nil }
   let(:suffix) { nil }
   let(:indent) { '' }


### PR DESCRIPTION
https://github.com/rubocop/rubocop/blob/master/docs/modules/ROOT/pages/development.adoc#implementation mentions:

> The `on_send` callback is the most used and can be optimized by restricting the acceptable method names with a constant `RESTRICT_ON_SEND`.

Blocked by #3.