### PR TITLE
Use `Cop::Base` API for `ThreadSafety` department

### DIFF
--- a/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
+++ b/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   class User
       #     cattr_accessor :current_user
       #   end
-      class ClassAndModuleAttributes < Cop
+      class ClassAndModuleAttributes < Base
         MSG = 'Avoid mutating class and module attributes.'
         RESTRICT_ON_SEND = %i[
           mattr_writer mattr_accessor cattr_writer cattr_accessor

--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -53,7 +53,7 @@ module RuboCop
       #
       #     module_function :test
       #   end
-      class InstanceVariableInClassMethod < Cop
+      class InstanceVariableInClassMethod < Base
         MSG = 'Avoid instance variables in class methods.'
         RESTRICT_ON_SEND = %i[
           instance_variable_set
@@ -73,7 +73,7 @@ module RuboCop
           return if method_definition?(node)
           return if synchronized?(node)
 
-          add_offense(node, location: :name, message: MSG)
+          add_offense(node.loc.name, message: MSG)
         end
         alias on_ivasgn on_ivar
 

--- a/lib/rubocop/cop/thread_safety/new_thread.rb
+++ b/lib/rubocop/cop/thread_safety/new_thread.rb
@@ -10,7 +10,7 @@ module RuboCop
       # @example
       #   # bad
       #   Thread.new { do_work }
-      class NewThread < Cop
+      class NewThread < Base
         MSG = 'Avoid starting new threads.'
         RESTRICT_ON_SEND = %i[new].freeze
 


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/7868.

The legacy `Cop::Cop` API is soft deprecated and this PR use new `Cop::Base` API instead.

> maintain any RuboCop extensions, as the legacy API will be removed in RuboCop 2.0.

https://metaredux.com/posts/2020/10/21/rubocop-1-0.html

This new API requires RuboCop 0.87 or higher.
https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#0870-2020-07-06

That dependent version update will be resolved in #7, so there are no updates in this PR.