### PR TITLE
Disallow instance variables in `ActiveSupport::Concern#class_methods`

### DIFF
--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -39,6 +39,14 @@ module RuboCop
       #   end
       #
       #   module Example
+      #     class_methods do
+      #       def test(params)
+      #         @params = params
+      #       end
+      #     end
+      #   end
+      #
+      #   module Example
       #     module_function
       #
       #     def test(params)
@@ -111,6 +119,8 @@ module RuboCop
         end
 
         def in_def_class_methods?(node)
+          return true if in_def_class_methods_dsl?(node)
+
           defn = node.ancestors.find(&:def_type?)
           return unless defn
 
@@ -120,6 +130,15 @@ module RuboCop
           return unless mod
 
           class_methods_module?(mod)
+        end
+
+        def in_def_class_methods_dsl?(node)
+          node.ancestors.any? do |ancestor|
+            next unless ancestor.block_type?
+            next unless ancestor.children.first.is_a? AST::SendNode
+
+            ancestor.children.first.command? :class_methods
+          end
         end
 
         def in_def_module_function?(node)

--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -119,17 +119,7 @@ module RuboCop
         end
 
         def in_def_class_methods?(node)
-          return true if in_def_class_methods_dsl?(node)
-
-          defn = node.ancestors.find(&:def_type?)
-          return unless defn
-
-          mod = defn.ancestors.find do |ancestor|
-            %i[class module].include?(ancestor.type)
-          end
-          return unless mod
-
-          class_methods_module?(mod)
+          in_def_class_methods_dsl?(node) || in_def_class_methods_module?(node)
         end
 
         def in_def_class_methods_dsl?(node)
@@ -139,6 +129,18 @@ module RuboCop
 
             ancestor.children.first.command? :class_methods
           end
+        end
+
+        def in_def_class_methods_module?(node)
+          defn = node.ancestors.find(&:def_type?)
+          return unless defn
+
+          mod = defn.ancestors.find do |ancestor|
+            %i[class module].include?(ancestor.type)
+          end
+          return unless mod
+
+          class_methods_module?(mod)
         end
 
         def in_def_module_function?(node)

--- a/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
+++ b/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
@@ -71,6 +71,19 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod, :confi
     RUBY
   end
 
+  it 'registers an offense for assigning an ivar in class_methods' do
+    expect_offense(<<~RUBY)
+      module Test
+        class_methods do
+          def some_method(params)
+            @params = params
+            ^^^^^^^ Avoid instance variables in class methods.
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'registers an offense for assigning an ivar in a class singleton method' do
     expect_offense(<<~RUBY)
       class Test
@@ -125,6 +138,19 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod, :confi
         def some_method(params)
           instance_variable_set(:@params, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid instance variables in class methods.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for ivar_set in class_methods' do
+    expect_offense(<<~RUBY)
+      module Test
+        class_methods do
+          def some_method(params)
+            instance_variable_set(:@params, params)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid instance variables in class methods.
+          end
         end
       end
     RUBY


### PR DESCRIPTION
Closes #5 

Methods defined in [`ActiveSupport::Concern#class_methods`](https://api.rubyonrails.org/classes/ActiveSupport/Concern.html#method-i-class_methods) blocks are used as class methods.
I added a rule to disallow instance variables in `class_methods` blocks.

```ruby
module Example
  extend ActiveSupport::Concern

  class_methods do
    def test(params)
      @params = params
      ^^^^^^^ Avoid instance variables in class methods.
    end
  end
end
```

Cases using module `ClassMethods` can already be detected. ( https://github.com/covermymeds/rubocop-thread_safety/pull/31 ) 

```ruby
module Example
  extend ActiveSupport::Concern

  module ClassMethods do
    def test(params)
      @params = params
      ^^^^^^^ Avoid instance variables in class methods.
    end
  end
end
```