### PR TITLE
Mark MutableClassInstanceVariable as unsafe about auto-correction

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -14,6 +14,7 @@ ThreadSafety/MutableClassInstanceVariable:
   Description: 'Do not assign mutable objects to class instance variables.'
   Enabled: true
   EnforcedStyle: literals
+  SafeAutoCorrect: false
   SupportedStyles:
     # literals: freeze literals assigned to constants
     # strict: freeze all constants


### PR DESCRIPTION
This PR marks all cops for thread safety as unsafe.


# Problem

RuboCop auto-corrects an offense added by ThreadSafety cops by default, and it can change code meaning.
For example:

```ruby
class C
  @mapping = {}

  def update_mapping(k, v)
    @mapping[k] = v
  end
end
```

This code is changed to `@mapping = {}.freeze` by `rubocop --autocorrect`. This code actually breaks the behavior because the `@mapping` variable is mutated. 

# Solution

Add `Safe: false` to all cops. 

I also considered using `SafeAutoCorrect`, but I think `Safe` is more appropriate.

The definitions of `SafeAutoCorrect` and `Safe` are here:

> Safe (true/false) - indicates whether the cop can yield false positives (by design) or not.
>
> SafeAutoCorrect (true/false) - indicates whether the auto-correct a cop does is safe (equivalent) by design. If a cop is unsafe its auto-correct automatically becomes unsafe as well.
>
> https://docs.rubocop.org/rubocop/usage/auto_correct.html#safe-auto-correct


These cops can yield false positives. For example, If the `@mapping` variable is used only by a single thread, such as booting time, we do not need to care about multi-threading. I think the offense is a false positive in this case.

But I'm not 100% sure about this opinion. Maybe `SafeAutoCorrect` is enough. I'd like to hear other opinions.