### PR TITLE
Fix error for non-node elements when detecting instance variables in module_function

### DIFF
--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -181,7 +181,7 @@ module RuboCop
         end
 
         def module_function_bare_access_modifier?(node)
-          return false unless node
+          return false unless node.respond_to?(:send_type?)
 
           node.send_type? && node.bare_access_modifier? && node.method?(:module_function)
         end


### PR DESCRIPTION
Fixes #23 .

The bug was introduced by my PR: https://github.com/covermymeds/rubocop-thread_safety/pull/46.
`RuboCop::AST::Node#left_siblings` returns not only `RuboCop::AST::Node` but also non-node elements including nil or symbol. It causes `undefined method 'send_type?' for :helper_method:Symbol` like #23 .

I've fixed it by checking `respond_to?(:send_type?)`.

ref:
https://github.com/rubocop/rubocop-ast/blob/14844626f0c6f87aef0e74198769537b40b21b7b/lib/rubocop/ast/node.rb#L197-L200
https://github.com/rubocop/rubocop-ast/blob/14844626f0c6f87aef0e74198769537b40b21b7b/lib/rubocop/ast/node/mixin/descendence.rb#L11-L12
