### PR TITLE
Change CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:
@@ -15,12 +19,12 @@ jobs:
     env:
       BUNDLE_GEMFILE: "gemfiles/rubocop_${{ matrix.rubocop_version }}.gemfile"
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true # 'bundle install' and cache gems
-        ruby-version: ${{ matrix.ruby }}
-        bundler: 2.3.26
-    - name: Run tests
-      run: bundle exec rspec
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # 'bundle install' and cache gems
+          ruby-version: ${{ matrix.ruby }}
+          bundler: 2.3.26
+      - name: Run tests
+        run: bundle exec rspec

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
-name: Lint 
+name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:
@@ -9,11 +13,11 @@ jobs:
     name: Rubocop
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true # 'bundle install' and cache gems
-        ruby-version: "2.7" 
-    - name: Run Rubocop 
-      run: bundle exec rubocop
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # 'bundle install' and cache gems
+          ruby-version: "2.7"
+      - name: Run Rubocop
+        run: bundle exec rubocop


### PR DESCRIPTION
`on: [push, pull_request]` caused us to run each job twice every time someone push a commit to an open pull request.

With the new configuration, we run CI _once_ when opening a PR, and _once_ when pushing a commit that belongs to a pull request. And _once_ when merging to master (the `push` event). Importantly, this configuration still works for contributions from forked repositories, since the `pull_request` events are triggered on _our_ fork.