### PR TITLE
Remove ActiveSupport `class_attribute` detection

### DIFF
--- a/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
+++ b/lib/rubocop/cop/thread_safety/class_and_module_attributes.rb
@@ -42,16 +42,8 @@ module RuboCop
             ...)
         MATCHER
 
-        # @!method class_attr?(node)
-        def_node_matcher :class_attr?, <<~MATCHER
-          (send nil?
-            :class_attribute
-            ...)
-        MATCHER
-
         def on_send(node)
-          return unless mattr?(node) || class_attr?(node) ||
-                        singleton_attr?(node)
+          return unless mattr?(node) || singleton_attr?(node)
 
           add_offense(node)
         end

--- a/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
+++ b/spec/rubocop/cop/thread_safety/class_and_module_attributes_spec.rb
@@ -141,15 +141,6 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ClassAndModuleAttributes, :config do
     RUBY
   end
 
-  it 'registers an offense for `class_attribute`' do
-    expect_offense(<<~RUBY)
-      class Test
-        class_attribute :foobar
-        ^^^^^^^^^^^^^^^^^^^^^^^ #{msg}
-      end
-    RUBY
-  end
-
   it 'registers no offense for other class macro calls' do
     expect_no_offenses(<<~RUBY)
       class Test


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop-thread_safety/issues/34