### PR TITLE
Fix some`ThreadSafety::InstanceVariableInClassMethod` false positive offenses

### DIFF
--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -82,6 +82,7 @@ module RuboCop
           return unless class_method_definition?(node)
           return if method_definition?(node)
           return if synchronized?(node)
+          return if node.each_ancestor(:block).any? { new_lexical_scope?(_1) }
 
           add_offense(node.loc.name)
         end
@@ -92,6 +93,7 @@ module RuboCop
           return unless class_method_definition?(node)
           return if method_definition?(node)
           return if synchronized?(node)
+          return if node.each_ancestor(:block).any? { new_lexical_scope?(_1) }
 
           add_offense(node)
         end
@@ -198,6 +200,15 @@ module RuboCop
         # @!method module_function_for?(node)
         def_node_matcher :module_function_for?, <<~PATTERN
           (send nil? {:module_function} ({sym str} #match_name?(%1)))
+        PATTERN
+
+        # @!method new_lexical_scope?(node)
+        def_node_matcher :new_lexical_scope?, <<~PATTERN
+          {
+            (block (send (const nil? :Struct) :new ...) _ (def ...))
+            (block (send (const nil? :Class) :new ...) _ (def ...))
+            (block (send (const nil? :Data) :define ...) _ (def ...))
+          }
         PATTERN
       end
     end

--- a/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
+++ b/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
@@ -105,14 +105,14 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod, :confi
     RUBY
   end
 
-  # FIXME: This is a false negative.
-  it 'does not register an offense for reading an ivar in a nested class method' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense for reading an ivar in a nested class method' do # rubocop:disable RSpec/ExampleLength
+    expect_offense(<<~RUBY)
       class Test
         define_method :generate_new_class do
           Class.new do
             def self.area
               @area ||= some_computation
+              ^^^^^ Avoid instance variables in class methods.
             end
           end
         end


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-thread_safety/issues/28, fixes https://github.com/rubocop/rubocop-thread_safety/issues/16, fixes https://github.com/rubocop/rubocop-thread_safety/issues/13

Detecting `Data.define`, `Struct.new` and `Class.new` is essentially the same as detecting `define_method` ancestors.

NOTE: there is a common issue for both new and existing logic: we do not check if new-lexical-scope-ancestor is also an ancestor for class method. See https://github.com/viralpraxis/rubocop-thread_safety/blob/9a7e9437aadaf3f6fdbe5e847c19542361f6cd92/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb#L108 for false negative example

I'll try to evaluate performance impact and check if it the issue mentioned above is fixable