### PR TITLE
Fix outdated and not working links

### DIFF
--- a/docs/modules/ROOT/pages/cops_threadsafety.adoc
+++ b/docs/modules/ROOT/pages/cops_threadsafety.adoc
@@ -155,7 +155,7 @@ Checks whether some class instance variable isn't a
 mutable literal (e.g. array or hash).
 
 It is based on Style/MutableConstant from RuboCop.
-See https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/style/mutable_constant.rb
+See https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cop/style/mutable_constant.rb
 
 Class instance variables are a risk to threaded code as they are shared
 between threads. A mutable object such as an array or hash may be

--- a/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
+++ b/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
@@ -7,7 +7,7 @@ module RuboCop
       # mutable literal (e.g. array or hash).
       #
       # It is based on Style/MutableConstant from RuboCop.
-      # See https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/style/mutable_constant.rb
+      # See https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cop/style/mutable_constant.rb
       #
       # Class instance variables are a risk to threaded code as they are shared
       # between threads. A mutable object such as an array or hash may be

--- a/lib/rubocop/thread_safety/inject.rb
+++ b/lib/rubocop/thread_safety/inject.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# The original code is from https://github.com/rubocop-hq/rubocop-rspec/blob/master/lib/rubocop/rspec/inject.rb
-# See https://github.com/rubocop-hq/rubocop-rspec/blob/master/MIT_LICENSE.md
+# The original code is from https://github.com/rubocop/rubocop-rspec/blob/master/lib/rubocop/rspec/inject.rb
+# See https://github.com/rubocop/rubocop-rspec/blob/master/MIT-LICENSE.md
 module RuboCop
   module ThreadSafety
     # Because RuboCop doesn't yet support plugins, we have to monkey patch in a


### PR DESCRIPTION
Minor fix of outdated `rubocop-hq` namespaces (now they use just `rubocop`). Also, `MIT_LICENSE` changed to `MIT-LICENSE`

FYI @mikegee 