### PR TITLE
Add `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change log
+
+## master (unreleased)
+
+* [#43](https://github.com/rubocop/rubocop-thread_safety/pull/43): Make detection of ActiveSupport's `class_attribute` configurable. ([@viralpraxis][])
+* [#42](https://github.com/rubocop/rubocop-thread_safety/pull/42): Fix some `InstanceVariableInClassMethod` cop false positive offenses. ([@viralpraxis][])
+* [#41](https://github.com/rubocop/rubocop-thread_safety/pull/41): Drop support for MRI older than 2.7. ([@viralpraxis][])
+* [#38](https://github.com/rubocop/rubocop-thread_safety/pull/38): Fix `NewThread` detection is case of `Thread.start`, `Thread.fork`, or `Thread.new` with arguments. ([@viralpraxis][])
+* [#36](https://github.com/rubocop/rubocop-thread_safety/pull/36): Add new `ThreadSafety::DirChdir` to detect `Dir.chdir` calls. ([@viralpraxis][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,5 @@
 * [#43](https://github.com/rubocop/rubocop-thread_safety/pull/43): Make detection of ActiveSupport's `class_attribute` configurable. ([@viralpraxis][])
 * [#42](https://github.com/rubocop/rubocop-thread_safety/pull/42): Fix some `InstanceVariableInClassMethod` cop false positive offenses. ([@viralpraxis][])
 * [#41](https://github.com/rubocop/rubocop-thread_safety/pull/41): Drop support for MRI older than 2.7. ([@viralpraxis][])
-* [#38](https://github.com/rubocop/rubocop-thread_safety/pull/38): Fix `NewThread` detection is case of `Thread.start`, `Thread.fork`, or `Thread.new` with arguments. ([@viralpraxis][])
-* [#36](https://github.com/rubocop/rubocop-thread_safety/pull/36): Add new `ThreadSafety::DirChdir` to detect `Dir.chdir` calls. ([@viralpraxis][])
+* [#38](https://github.com/rubocop/rubocop-thread_safety/pull/38): Fix `NewThread` cop detection is case of `Thread.start`, `Thread.fork`, or `Thread.new` with arguments. ([@viralpraxis][])
+* [#36](https://github.com/rubocop/rubocop-thread_safety/pull/36): Add new `DirChdir` cop to detect `Dir.chdir` calls. ([@viralpraxis][])

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -22,6 +22,12 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
 
+  spec.metadata = {
+    'changelog_uri' => 'https://github.com/rubocop/rubocop-thread_safety/blob/master/CHANGELOG.md',
+    'source_code_uri' => 'https://github.com/rubocop/rubocop-thread_safety',
+    'bug_tracker_uri' => 'https://github.com/rubocop/rubocop-thread_safety/issues'
+  }
+
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-thread_safety/issues/39

I've used simplified rubocop's changelog format: https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md