### PR TITLE
Enable new rubocop cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ require:
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.7
+  NewCops: enable
 
 Lint/RaiseException:
   Enabled: true
@@ -80,3 +81,9 @@ Style/SymbolArray:
 
 RSpec/ExampleLength:
   Max: 11
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
+Gemspec/RequireMFA:
+  Enabled: false

--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -144,19 +144,19 @@ module RuboCop
 
             ancestor.def_type?
           end
-          return unless defn
+          return false unless defn
 
           mod = defn.ancestors.find do |ancestor|
             %i[class module].include?(ancestor.type)
           end
-          return unless mod
+          return false unless mod
 
           class_methods_module?(mod)
         end
 
         def in_def_module_function?(node)
           defn = node.ancestors.find(&:def_type?)
-          return unless defn
+          return false unless defn
 
           defn.left_siblings.any? { |sibling| module_function_bare_access_modifier?(sibling) } ||
             defn.right_siblings.any? { |sibling| module_function_for?(sibling, defn.method_name) }

--- a/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
+++ b/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
@@ -181,7 +181,7 @@ module RuboCop
         end
 
         def mutable_literal?(node)
-          return if node.nil?
+          return false if node.nil?
 
           node.mutable_literal? || range_type?(node)
         end

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.92.0'
+  spec.add_dependency 'rubocop', '>= 0.92.0'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'


### PR DESCRIPTION
`Gemspec/RequireMFA` is disabled because it would require enabling rubygems MFA.