### PR TITLE
Fix instance variables misdetection in `ActionDispatch` callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#48](https://github.com/rubocop/rubocop-thread_safety/pull/48): Do not report instance variables in `ActionDispatch` callbacks in singleton methods. ([@viralpraxis][])
 * [#43](https://github.com/rubocop/rubocop-thread_safety/pull/43): Make detection of ActiveSupport's `class_attribute` configurable. ([@viralpraxis][])
 * [#42](https://github.com/rubocop/rubocop-thread_safety/pull/42): Fix some `InstanceVariableInClassMethod` cop false positive offenses. ([@viralpraxis][])
 * [#41](https://github.com/rubocop/rubocop-thread_safety/pull/41): Drop support for MRI older than 2.7. ([@viralpraxis][])

--- a/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
+++ b/lib/rubocop/cop/thread_safety/instance_variable_in_class_method.rb
@@ -219,6 +219,22 @@ module RuboCop
             (block (send (const nil? :Struct) :new ...) _ ({def defs} ...))
             (block (send (const nil? :Class) :new ...) _ ({def defs} ...))
             (block (send (const nil? :Data) :define ...) _ ({def defs} ...))
+            (block
+              (send nil?
+                {
+                  :prepend_around_action
+                  :prepend_before_action
+                  :before_action
+                  :append_before_action
+                  :around_action
+                  :append_around_action
+                  :append_after_action
+                  :after_action
+                  :prepend_after_action
+                }
+              )
+              ...
+            )
           }
         PATTERN
       end

--- a/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
+++ b/spec/rubocop/cop/thread_safety/instance_variable_in_class_method_spec.rb
@@ -385,4 +385,28 @@ RSpec.describe RuboCop::Cop::ThreadSafety::InstanceVariableInClassMethod, :confi
       end
     RUBY
   end
+
+  context 'with `ActionDispatch` callbacks' do
+    %i[
+      prepend_around_action
+      prepend_before_action
+      before_action
+      append_before_action
+      around_action
+      append_around_action
+      append_after_action
+      after_action
+      prepend_after_action
+    ].each do |action_dispatch_callback_name|
+      it "registers no offense for `#{action_dispatch_callback_name}` callback" do
+        expect_no_offenses(<<~RUBY)
+          def self.foo
+            #{action_dispatch_callback_name} do
+              @language = :haskell
+            end
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-thread_safety/issues/4