### PR TITLE
Add `FileUtils` methods detection to `Dir::Chdir` cop

### DIFF
--- a/docs/modules/ROOT/pages/cops_threadsafety.adoc
+++ b/docs/modules/ROOT/pages/cops_threadsafety.adoc
@@ -62,6 +62,9 @@ Avoid using `Dir.chdir` due to its process-wide effect.
 ----
 # bad
 Dir.chdir("/var/run")
+
+# bad
+FileUtils.chdir("/var/run")
 ----
 
 == ThreadSafety/InstanceVariableInClassMethod

--- a/spec/rubocop/cop/thread_safety/dir_chdir_spec.rb
+++ b/spec/rubocop/cop/thread_safety/dir_chdir_spec.rb
@@ -26,6 +26,28 @@ RSpec.describe RuboCop::Cop::ThreadSafety::DirChdir, :config do
     end
   end
 
+  context 'with `FileUtils.chdir` method' do
+    let(:msg) { 'Avoid using `FileUtils.chdir` due to its process-wide effect.' }
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        FileUtils.chdir("/var/run")
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{msg}
+      RUBY
+    end
+  end
+
+  context 'with `FileUtils.cd` method' do
+    let(:msg) { 'Avoid using `FileUtils.cd` due to its process-wide effect.' }
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        FileUtils.cd("/var/run")
+        ^^^^^^^^^^^^^^^^^^^^^^^^ #{msg}
+      RUBY
+    end
+  end
+
   context 'with another `Dir` class method' do
     it 'does not register an offense' do
       expect_no_offenses 'Dir.pwd'


### PR DESCRIPTION
`FileUtils` is a bundled gem which provides aliased `cd` and `chdir` methods. They share process-wide semantics with `Dir.chdir`: https://github.com/ruby/fileutils/blob/master/lib/fileutils.rb#L239-L248