### PR TITLE
Enable `Gemspec::RequireMFA` rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,6 +90,3 @@ RSpec/ContextWording:
 
 Gemspec/DevelopmentDependencies:
   EnforcedStyle: gemspec
-
-Gemspec/RequireMFA:
-  Enabled: false

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -25,7 +25,8 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     'changelog_uri' => 'https://github.com/rubocop/rubocop-thread_safety/blob/master/CHANGELOG.md',
     'source_code_uri' => 'https://github.com/rubocop/rubocop-thread_safety',
-    'bug_tracker_uri' => 'https://github.com/rubocop/rubocop-thread_safety/issues'
+    'bug_tracker_uri' => 'https://github.com/rubocop/rubocop-thread_safety/issues',
+    'rubygems_mfa_required' => 'true'
   }
 
   spec.bindir        = 'exe'


### PR DESCRIPTION
Require MFA and enable corresponding rubocop rule, FYI @mikegee 