### PR TITLE
Fix wrong debug `path` inspection escape

### DIFF
--- a/lib/rubocop/thread_safety/inject.rb
+++ b/lib/rubocop/thread_safety/inject.rb
@@ -11,7 +11,7 @@ module RuboCop
         path = CONFIG_DEFAULT.to_s
         hash = ConfigLoader.__send__(:load_yaml_configuration, path)
         config = Config.new(hash, path).tap(&:make_excludes_absolute)
-        puts "configuration from \#{path}" if ConfigLoader.debug?
+        puts "configuration from #{path}" if ConfigLoader.debug?
         config = ConfigLoader.merge_with_default(config, path)
         ConfigLoader.instance_variable_set(:@default_configuration, config)
       end


### PR DESCRIPTION
```console
be rubocop -d

configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-performance-1.23.0/config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-performance-1.23.0/config/default.yml
Default configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-1.69.0/config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-rails-2.27.0/config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-rails-2.27.0/config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-rake-0.6.0/config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-rake-0.6.0/config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-capybara-2.21.0/config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-capybara-2.21.0/lib/../config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-factory_bot-2.26.1/config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-factory_bot-2.26.1/lib/../config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-rspec-3.2.0/config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-rspec-3.2.0/config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-rspec_rails-2.30.0/config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-rspec_rails-2.30.0/lib/../config/default.yml
configuration from ~/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rubocop-thread_safety-0.6.0/config/default.yml
configuration from #{path}
```

I was intrigued by this un-interpolated `#{path}` at the end, and it seems to be a bug in the gem. The reason for the `\` in the injection code remains a mystery. :^)