### PR TITLE
Add `AllowCallWithBlock` option to `ThreadSafety/DirChdir` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## master
+
+- [#73](https://github.com/rubocop/rubocop-thread_safety/pull/73): Add `AllowCallWithBlock` option to `ThreadSafety/DirChdir` cop. ([@viralpraxis](https://github.com/viralpraxis))
+
 ## 0.6.0
 
 * [#59](https://github.com/rubocop/rubocop-thread_safety/pull/59): Rename `ThreadSafety::InstanceVariableInClassMethod` cop to `ThreadSafety::ClassInstanceVariable` to better reflect its purpose. ([@viralpraxis](https://github.com/viralpraxis))

--- a/config/default.yml
+++ b/config/default.yml
@@ -35,6 +35,7 @@ ThreadSafety/NewThread:
 ThreadSafety/DirChdir:
   Description: Avoid using `Dir.chdir` due to its process-wide effect.
   Enabled: true
+  AllowCallWithBlock: false
 
 ThreadSafety/RackMiddlewareInstanceVariable:
   Description: Avoid instance variables in Rack middleware.

--- a/docs/modules/ROOT/pages/cops_threadsafety.adoc
+++ b/docs/modules/ROOT/pages/cops_threadsafety.adoc
@@ -136,6 +136,8 @@ end
 |===
 
 Avoid using `Dir.chdir` due to its process-wide effect.
+If `AllowCallWithBlock` (disabled by default) option is enabled,
+calling `Dir.chdir` with block will be allowed.
 
 [#examples-threadsafetydirchdir]
 === Examples
@@ -148,6 +150,39 @@ Dir.chdir("/var/run")
 # bad
 FileUtils.chdir("/var/run")
 ----
+
+[#allowcallwithblock_-false-_default_-threadsafetydirchdir]
+==== AllowCallWithBlock: false (default)
+
+[source,ruby]
+----
+# good
+Dir.chdir("/var/run") do
+  puts Dir.pwd
+end
+----
+
+[#allowcallwithblock_-true-threadsafetydirchdir]
+==== AllowCallWithBlock: true
+
+[source,ruby]
+----
+# bad
+Dir.chdir("/var/run") do
+  puts Dir.pwd
+end
+----
+
+[#configurable-attributes-threadsafetydirchdir]
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowCallWithBlock
+| `false`
+| Boolean
+|===
 
 [#threadsafetymutableclassinstancevariable]
 == ThreadSafety/MutableClassInstanceVariable

--- a/lib/rubocop/cop/thread_safety/dir_chdir.rb
+++ b/lib/rubocop/cop/thread_safety/dir_chdir.rb
@@ -4,6 +4,8 @@ module RuboCop
   module Cop
     module ThreadSafety
       # Avoid using `Dir.chdir` due to its process-wide effect.
+      # If `AllowCallWithBlock` (disabled by default) option is enabled,
+      # calling `Dir.chdir` with block will be allowed.
       #
       # @example
       #   # bad
@@ -11,6 +13,19 @@ module RuboCop
       #
       #   # bad
       #   FileUtils.chdir("/var/run")
+      #
+      # @example AllowCallWithBlock: false (default)
+      #   # good
+      #   Dir.chdir("/var/run") do
+      #     puts Dir.pwd
+      #   end
+      #
+      # @example AllowCallWithBlock: true
+      #   # bad
+      #   Dir.chdir("/var/run") do
+      #     puts Dir.pwd
+      #   end
+      #
       class DirChdir < Base
         MESSAGE = 'Avoid using `%<module>s.%<method>s` due to its process-wide effect.'
         RESTRICT_ON_SEND = %i[chdir cd].freeze
@@ -24,12 +39,19 @@ module RuboCop
         MATCHER
 
         def on_send(node)
-          chdir?(node) do
-            add_offense(
-              node,
-              message: format(MESSAGE, module: node.receiver.short_name, method: node.method_name)
-            )
-          end
+          return unless chdir?(node)
+          return if allow_call_with_block? && (node.block_argument? || node.parent&.block_type?)
+
+          add_offense(
+            node,
+            message: format(MESSAGE, module: node.receiver.short_name, method: node.method_name)
+          )
+        end
+
+        private
+
+        def allow_call_with_block?
+          !!cop_config['AllowCallWithBlock']
         end
       end
     end


### PR DESCRIPTION
Using `Dir.chdir` with provided block is much more safer than block-less call since it restores `PWD` to initial state . I think it makes sense to add an option to allow these safe calls.