### PR TITLE
Simplify node patterns: replace union of `send` and `csend` with `call`

### DIFF
--- a/lib/rubocop/cop/thread_safety/dir_chdir.rb
+++ b/lib/rubocop/cop/thread_safety/dir_chdir.rb
@@ -33,8 +33,8 @@ module RuboCop
         # @!method chdir?(node)
         def_node_matcher :chdir?, <<~MATCHER
           {
-            ({send csend} (const {nil? cbase} {:Dir :FileUtils}) :chdir ...)
-            ({send csend} (const {nil? cbase} :FileUtils) :cd ...)
+            (call (const {nil? cbase} {:Dir :FileUtils}) :chdir ...)
+            (call (const {nil? cbase} :FileUtils) :cd ...)
           }
         MATCHER
 

--- a/lib/rubocop/cop/thread_safety/new_thread.rb
+++ b/lib/rubocop/cop/thread_safety/new_thread.rb
@@ -16,7 +16,7 @@ module RuboCop
 
         # @!method new_thread?(node)
         def_node_matcher :new_thread?, <<~MATCHER
-          ({send csend} (const {nil? cbase} :Thread) {:new :fork :start} ...)
+          (call (const {nil? cbase} :Thread) {:new :fork :start} ...)
         MATCHER
 
         def on_send(node)


### PR DESCRIPTION
ref: https://github.com/rubocop/rubocop/issues/13745