### PR TITLE
Use node groups in node patterns to replace unions of types

### DIFF
--- a/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
+++ b/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
@@ -245,7 +245,7 @@ module RuboCop
 
         # @!method range_enclosed_in_parentheses?(node)
         def_node_matcher :range_enclosed_in_parentheses?, <<~PATTERN
-          (begin ({irange erange} _ _))
+          (begin (range _ _))
         PATTERN
       end
     end


### PR DESCRIPTION
`rubocop-ast` defines some node groups (https://github.com/rubocop/rubocop-ast/blob/85bfe84/lib/rubocop/ast/node.rb#L89-L116) that can be used in place of a union of node types.