### PR TITLE
Rename `InstanceVariableInClassMethod` in default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## 0.7.1
+
+- [#84](https://github.com/rubocop/rubocop-thread_safety/pull/84):  Rename `InstanceVariableInClassMethod` in default config ([@sambostock](https://github.com/sambostock))
+
 ## 0.7.0
 
 - [#80](https://github.com/rubocop/rubocop-thread_safety/pull/80) Make RuboCop ThreadSafety work as a RuboCop plugin. ([@bquorning](https://github.com/bquorning))

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,8 +7,8 @@ ThreadSafety/ClassAndModuleAttributes:
   Enabled: true
   ActiveSupportClassAttributeAllowed: false
 
-ThreadSafety/InstanceVariableInClassMethod:
-  Description: 'Avoid using instance variables in class methods.'
+ThreadSafety/ClassInstanceVariable:
+  Description: 'Avoid class instance variables.'
   Enabled: true
 
 ThreadSafety/MutableClassInstanceVariable:


### PR DESCRIPTION
This matches the behaviour upstream in `rubocop`, where the same commit that introduces a rename via `obsoletion.yml` also updates `default.yml` accordingly.

This should not impact consumers (unless they're [specifically inspecting the default config](https://github.com/Shopify/ruby-style-guide/pull/703#discussion_r1987599964)).