### PR TITLE
Use `:range`, not `:erange, :irange`

### DIFF
--- a/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
+++ b/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
@@ -198,7 +198,7 @@ module RuboCop
         end
 
         def range_type?(node)
-          node.type?(:erange, :irange)
+          node.type?(:range)
         end
 
         def correct_splat_expansion(corrector, expr, splat_value)


### PR DESCRIPTION
This was causing CI to fail due to

    InternalAffairs/NodeTypeGroup: Use :range instead of individually listing group types.
    node.type?(:erange, :irange)
               ^^^^^^^^^^^^^^^^