### PR TITLE
Fix Plugin info version resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [#88](https://github.com/rubocop/rubocop-thread_safety/pull/88): Fix incorrect plugin metadata version. ([@viralpraxis](https://github.com/viralpraxis))
+
 ## 0.7.1
 
 - [#84](https://github.com/rubocop/rubocop-thread_safety/pull/84): Rename `InstanceVariableInClassMethod` in default config ([@sambostock](https://github.com/sambostock))

--- a/lib/rubocop/thread_safety/version.rb
+++ b/lib/rubocop/thread_safety/version.rb
@@ -2,6 +2,8 @@
 
 module RuboCop
   module ThreadSafety
-    VERSION = '0.7.1'
+    module Version
+      STRING = '0.7.1'
+    end
   end
 end

--- a/rubocop-thread_safety.gemspec
+++ b/rubocop-thread_safety.gemspec
@@ -6,7 +6,7 @@ require 'rubocop/thread_safety/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-thread_safety'
-  spec.version       = RuboCop::ThreadSafety::VERSION
+  spec.version       = RuboCop::ThreadSafety::Version::STRING
   spec.authors       = ['Michael Gee']
   spec.email         = ['michaelpgee@gmail.com']
 

--- a/spec/rubocop/thread_safety_spec.rb
+++ b/spec/rubocop/thread_safety_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe RuboCop::ThreadSafety do
   it 'has a version number' do
-    expect(RuboCop::ThreadSafety::VERSION).not_to be_nil
+    expect(RuboCop::ThreadSafety::Version::STRING).to match(/\d+\.\d+.\d+/)
   end
 end


### PR DESCRIPTION
Before this change, since there was no 'Version::STRING', this constant refereced `RuboCop::Version::STRING`.

To fix that I could either change `plugin.rb`'s version constant to `VERSION` or use other plugins approach by actually defining `Version::STRING`.

```console
be rubocop -V
1.73.2 (using Parser 3.3.7.1, rubocop-ast 1.38.1, analyzing as Ruby 3.3, running on ruby 3.3.7) [x86_64-linux]
  - rubocop-factory_bot 2.27.0
  - rubocop-performance 1.24.0
  - rubocop-rails 2.30.3
  - rubocop-rake 0.7.1
  - rubocop-rspec 3.5.0
  - rubocop-thread_safety 1.73.2
  - rubocop-capybara 2.21.0
  - rubocop-rspec_rails 2.30.0
```