### PR TITLE
Docs: Ensure that Model initialization example is good as well

### DIFF
--- a/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
+++ b/lib/rubocop/cop/thread_safety/mutable_class_instance_variable.rb
@@ -41,7 +41,7 @@ module RuboCop
       #
       #   # good
       #   class Model
-      #     @var = Something.new
+      #     @var = Something.new.freeze
       #   end
       #
       # @example EnforcedStyle: strict


### PR DESCRIPTION
There was a typo in documentation with a bad example (with mutable object instance) was shown as a good example. I have corrected this example to show how to initialize a frozen object.