### PR TITLE
Run tests on `jruby-head` and *two* latest JRuby minor releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "4.0", ruby-head, jruby-9.4]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "4.0", ruby-head, jruby-9.4, jruby-10.0, jruby-head]
         rubocop_version: ["1.81"]
     env:
       BUNDLE_GEMFILE: "gemfiles/rubocop_${{ matrix.rubocop_version }}.gemfile"


### PR DESCRIPTION
I'd also want to run tests on `rubocop-head`, just like many other plugins do.