### PR TITLE
Add cop for process-wide ActiveSupport callback mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change log
 
+* [#107](https://github.com/rubocop/rubocop-thread_safety/pull/107): Add new `ThreadSafety/ActiveSupportCallbacks` cop. ([@mikegee][])
 * [#104](https://github.com/rubocop/rubocop-thread_safety/pull/104): Set minimum required RuboCop version to `1.81`. ([@viralpraxis][])
 * [#95](https://github.com/rubocop/rubocop-thread_safety/pull/95): Add new `ThreadSafety/MethodRedefinition` cop. ([@viralpraxis][])
 * [#91](https://github.com/rubocop/rubocop-thread_safety/pull/91): Make `ThreadSafety/MutableClassInstanceVariable` cop aware of `TestCase`'s `setup`/`teardown` DSL. ([@viralpraxis][])
@@ -36,5 +37,6 @@
 * [#36](https://github.com/rubocop/rubocop-thread_safety/pull/36): Add new `DirChdir` cop to detect `Dir.chdir` calls. ([@viralpraxis][])
 
 [@bquorning]: https://github.com/bquorning
+[@mikegee]: https://github.com/mikegee
 [@sambostock]: https://github.com/sambostock
 [@viralpraxis]: https://github.com/viralpraxis

--- a/config/default.yml
+++ b/config/default.yml
@@ -3,7 +3,7 @@
 # Without adding these to your rubocop config, these values will be the default.
 
 ThreadSafety/ActiveSupportCallbacks:
-  Description: 'Avoid mutating ActiveSupport callbacks with an explicit constant receiver.'
+  Description: 'Avoid mutating ActiveSupport callback chains at runtime.'
   Enabled: true
   VersionAdded: '<<next>>'
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,6 +2,11 @@
 #
 # Without adding these to your rubocop config, these values will be the default.
 
+ThreadSafety/ActiveSupportCallbacks:
+  Description: 'Avoid mutating ActiveSupport callbacks with an explicit constant receiver.'
+  Enabled: true
+  VersionAdded: '<<next>>'
+
 ThreadSafety/ClassAndModuleAttributes:
   Description: 'Avoid mutating class and module attributes.'
   Enabled: true

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -1,5 +1,6 @@
 === Department xref:cops_threadsafety.adoc[ThreadSafety]
 
+* xref:cops_threadsafety.adoc#threadsafetyactivesupportcallbacks[ThreadSafety/ActiveSupportCallbacks]
 * xref:cops_threadsafety.adoc#threadsafetyclassandmoduleattributes[ThreadSafety/ClassAndModuleAttributes]
 * xref:cops_threadsafety.adoc#threadsafetyclassinstancevariable[ThreadSafety/ClassInstanceVariable]
 * xref:cops_threadsafety.adoc#threadsafetymutableclassinstancevariable[ThreadSafety/MutableClassInstanceVariable]

--- a/docs/modules/ROOT/pages/cops_threadsafety.adoc
+++ b/docs/modules/ROOT/pages/cops_threadsafety.adoc
@@ -19,7 +19,7 @@
 | -
 |===
 
-Avoid mutating ActiveSupport callbacks with an explicit constant receiver.
+Avoid mutating ActiveSupport callback chains at runtime.
 
 Calls such as `User.skip_callback` and `User.set_callback` mutate callback
 chains at process scope.

--- a/docs/modules/ROOT/pages/cops_threadsafety.adoc
+++ b/docs/modules/ROOT/pages/cops_threadsafety.adoc
@@ -6,6 +6,44 @@
 
 = ThreadSafety
 
+[#threadsafetyactivesupportcallbacks]
+== ThreadSafety/ActiveSupportCallbacks
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Enabled
+| Yes
+| No
+| <<next>>
+| -
+|===
+
+Avoid mutating ActiveSupport callbacks with an explicit constant receiver.
+
+Calls such as `User.skip_callback` and `User.set_callback` mutate callback
+chains at process scope.
+
+[#examples-threadsafetyactivesupportcallbacks]
+=== Examples
+
+[source,ruby]
+----
+# bad
+Site.skip_callback(:commit, :after, :after_owner_change)
+
+# bad
+Site.set_callback(
+  :commit, :after, :after_owner_change,
+  if: :saved_change_to_owner?
+)
+
+# good
+class User < ApplicationRecord
+  skip_callback :commit, :after, :after_owner_change
+end
+----
+
 [#threadsafetyclassandmoduleattributes]
 == ThreadSafety/ClassAndModuleAttributes
 

--- a/lib/rubocop-thread_safety.rb
+++ b/lib/rubocop-thread_safety.rb
@@ -8,6 +8,7 @@ require 'rubocop/thread_safety/plugin'
 
 require 'rubocop/cop/mixin/operation_with_threadsafe_result'
 
+require 'rubocop/cop/thread_safety/active_support_callbacks'
 require 'rubocop/cop/thread_safety/class_instance_variable'
 require 'rubocop/cop/thread_safety/class_and_module_attributes'
 require 'rubocop/cop/thread_safety/mutable_class_instance_variable'

--- a/lib/rubocop/cop/thread_safety/active_support_callbacks.rb
+++ b/lib/rubocop/cop/thread_safety/active_support_callbacks.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module ThreadSafety
-      # Avoid mutating ActiveSupport callbacks with an explicit constant receiver.
+      # Avoid mutating ActiveSupport callback chains at runtime.
       #
       # Calls such as `User.skip_callback` and `User.set_callback` mutate callback
       # chains at process scope.
@@ -23,6 +23,8 @@ module RuboCop
       #     skip_callback :commit, :after, :after_owner_change
       #   end
       class ActiveSupportCallbacks < Base
+        requires_gem 'activesupport'
+
         MSG = 'Avoid process-wide ActiveSupport callback mutation with `%<expression>s`.'
         RESTRICT_ON_SEND = %i[set_callback skip_callback].freeze
 

--- a/lib/rubocop/cop/thread_safety/active_support_callbacks.rb
+++ b/lib/rubocop/cop/thread_safety/active_support_callbacks.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module ThreadSafety
+      # Avoid mutating ActiveSupport callbacks with an explicit constant receiver.
+      #
+      # Calls such as `User.skip_callback` and `User.set_callback` mutate callback
+      # chains at process scope.
+      #
+      # @example
+      #   # bad
+      #   Site.skip_callback(:commit, :after, :after_owner_change)
+      #
+      #   # bad
+      #   Site.set_callback(
+      #     :commit, :after, :after_owner_change,
+      #     if: :saved_change_to_owner?
+      #   )
+      #
+      #   # good
+      #   class User < ApplicationRecord
+      #     skip_callback :commit, :after, :after_owner_change
+      #   end
+      class ActiveSupportCallbacks < Base
+        MSG = 'Avoid process-wide ActiveSupport callback mutation with `%<expression>s`.'
+        RESTRICT_ON_SEND = %i[set_callback skip_callback].freeze
+
+        def on_send(node)
+          return unless constant_receiver?(node.receiver)
+
+          add_offense(node.loc.selector, message: format(MSG, expression: callback_call(node)))
+        end
+        alias on_csend on_send
+
+        private
+
+        def constant_receiver?(receiver)
+          receiver = receiver.children.first while receiver&.begin_type? && receiver.children.one?
+
+          receiver&.const_type?
+        end
+
+        def callback_call(node)
+          "#{node.receiver.source}#{node.loc.dot.source}#{node.method_name}"
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/thread_safety/active_support_callbacks_spec.rb
+++ b/spec/rubocop/cop/thread_safety/active_support_callbacks_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::ThreadSafety::ActiveSupportCallbacks, :config do
+  let(:gem_versions) { { 'activesupport' => '7.0.0' } }
+
   it 'registers an offense for `skip_callback` with a constant receiver' do
     expect_offense(<<~RUBY)
       Site.skip_callback(:commit, :after, :after_owner_change)
@@ -64,5 +66,15 @@ RSpec.describe RuboCop::Cop::ThreadSafety::ActiveSupportCallbacks, :config do
     expect_no_offenses(<<~RUBY)
       Site.after_commit :after_owner_change
     RUBY
+  end
+
+  context 'without ActiveSupport' do
+    let(:gem_versions) { {} }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        Site.skip_callback(:commit, :after, :after_owner_change)
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/thread_safety/active_support_callbacks_spec.rb
+++ b/spec/rubocop/cop/thread_safety/active_support_callbacks_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::ThreadSafety::ActiveSupportCallbacks, :config do
+  it 'registers an offense for `skip_callback` with a constant receiver' do
+    expect_offense(<<~RUBY)
+      Site.skip_callback(:commit, :after, :after_owner_change)
+           ^^^^^^^^^^^^^ Avoid process-wide ActiveSupport callback mutation with `Site.skip_callback`.
+    RUBY
+  end
+
+  it 'registers an offense for `set_callback` with a constant receiver' do
+    expect_offense(<<~RUBY)
+      Site.set_callback(:commit, :after, :after_owner_change, if: :saved_change_to_owner?)
+           ^^^^^^^^^^^^ Avoid process-wide ActiveSupport callback mutation with `Site.set_callback`.
+    RUBY
+  end
+
+  it 'registers an offense for fully qualified constant receivers' do
+    expect_offense(<<~RUBY)
+      ::Site.skip_callback(:commit, :after, :after_owner_change)
+             ^^^^^^^^^^^^^ Avoid process-wide ActiveSupport callback mutation with `::Site.skip_callback`.
+    RUBY
+  end
+
+  it 'registers an offense for nested constant receivers' do
+    expect_offense(<<~RUBY)
+      Admin::Site.set_callback(:commit, :after, :after_owner_change)
+                  ^^^^^^^^^^^^ Avoid process-wide ActiveSupport callback mutation with `Admin::Site.set_callback`.
+    RUBY
+  end
+
+  it 'registers an offense for parenthesized constant receivers' do
+    expect_offense(<<~RUBY)
+      (Site).set_callback(:commit, :after, :after_owner_change)
+             ^^^^^^^^^^^^ Avoid process-wide ActiveSupport callback mutation with `(Site).set_callback`.
+    RUBY
+  end
+
+  it 'registers an offense for safe navigation with a constant receiver' do
+    expect_offense(<<~RUBY)
+      Site&.skip_callback(:commit, :after, :after_owner_change)
+            ^^^^^^^^^^^^^ Avoid process-wide ActiveSupport callback mutation with `Site&.skip_callback`.
+    RUBY
+  end
+
+  it 'does not register an offense for ActiveSupport callback DSL calls' do
+    expect_no_offenses(<<~RUBY)
+      class User < ApplicationRecord
+        skip_callback :commit, :after, :after_owner_change
+        set_callback :commit, :after, :after_owner_change, if: :saved_change_to_owner?
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for explicit non-constant receivers' do
+    expect_no_offenses(<<~RUBY)
+      site.skip_callback(:commit, :after, :after_owner_change)
+      callback_owner.set_callback(:commit, :after, :after_owner_change)
+      self.skip_callback(:commit, :after, :after_owner_change)
+    RUBY
+  end
+
+  it 'does not register an offense for unrelated methods on constant receivers' do
+    expect_no_offenses(<<~RUBY)
+      Site.after_commit :after_owner_change
+    RUBY
+  end
+end


### PR DESCRIPTION
## Summary

- Add `ThreadSafety/ActiveSupportCallbacks` to flag `set_callback` / `skip_callback` calls with explicit constant receivers.
- Allow normal class-body ActiveSupport callback DSL usage.
- Wire the cop into default config, require loading, specs, and generated docs.

Resolves #65.