### PR TITLE
Use latest Bundler for ruby-head CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           bundler-cache: true # 'bundle install' and cache gems
           ruby-version: ${{ matrix.ruby }}
-          bundler: 2.3.26
+          bundler: ${{ matrix.ruby == 'ruby-head' && 'latest' || '2.3.26' }}
       - name: Run tests
         run: bundle exec rspec
 


### PR DESCRIPTION
This PR fixes the ruby-head CI setup failure by using the latest Bundler only for the ruby-head matrix entry while preserving Bundler 2.3.26 elsewhere.

Baseline confirmation: the first draft version of this PR changed only a scratch file, and its pull_request CI failed on test (ruby-head, 1.81), confirming the failure exists against the current codebase before this workflow fix.