### PR TITLE
Add `irb` to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 gem 'appraisal'
 gem 'bundler', '>= 1.10'
+gem 'irb'
 gem 'pry' unless ENV['CI']
 gem 'rake', '>= 10.0'
 gem 'rspec', '~> 3.0'


### PR DESCRIPTION
On MRI 3:

```shell
$ irb
3.4.8/lib/ruby/gems/3.4.0/gems/irb-1.14.3/exe/irb:7: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 4.0.0.
You can add irb to your Gemfile or gemspec to silence this warning.
ruby/3.4.8/lib/ruby/3.4.0/irb/input-method.rb:278: warning: rdoc was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 4.0.0.
You can add rdoc to your Gemfile or gemspec to silence this warning.
```

On MRI 4:

```shell
$ irb
ruby/4.0.3/lib/ruby/gems/4.0.0/gems/bundler-4.0.3/lib/bundler/rubygems_integration.rb:236:in 'block in Gem.replace_bin_path':
  can't find executable irb for gem irb. irb is not currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)
```